### PR TITLE
Django 2 compatibility fix for value_to_string

### DIFF
--- a/recurrence/fields.py
+++ b/recurrence/fields.py
@@ -44,7 +44,7 @@ class RecurrenceField(fields.Field):
         setattr(cls, self.name, Creator(self))
 
     def value_to_string(self, obj):
-        return self.get_prep_value(self._get_val_from_obj(obj))
+        return self.get_prep_value(self.value_from_object(obj))
 
     def formfield(self, **kwargs):
         defaults = {


### PR DESCRIPTION
As discussed [here](https://code.djangoproject.com/ticket/24716) the use of _get_val_from_obj inside the value_to_string method is deprecated and then removed in Django 2.